### PR TITLE
Move Matomo.hooks.php to src/Hooks.php and adjust loading

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <ruleset>
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
 		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
 		<exclude name="Generic.Files.LineLength.TooLong" />
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,9 @@
 		"composer/installers": "1.*,>=1.0.1"
 	},
 	"autoload": {
-		"classmap": [
-			"Matomo.hooks.php"
-		]
+		"psr-4": {
+			"MediaWiki\\Extension\\Matomo\\": "src/"
+		}
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "38.0.0",

--- a/extension.json
+++ b/extension.json
@@ -30,17 +30,17 @@
 	},
 	"Hooks": {
 		"SkinAfterBottomScripts": [
-			"MatomoHooks::MatomoSetup"
+			"MediaWiki\\Extension\\Matomo\\Hooks::MatomoSetup"
 		],
 		"SpecialSearchResults": [
-			"MatomoHooks::onSpecialSearchResults"
+			"MediaWiki\\Extension\\Matomo\\Hooks::onSpecialSearchResults"
 		],
 		"SpecialSearchSetupEngine": [
-			"MatomoHooks::onSpecialSearchSetupEngine"
+			"MediaWiki\\Extension\\Matomo\\Hooks::onSpecialSearchSetupEngine"
 		]
 	},
 	"AutoloadClasses": {
-		"MatomoHooks": "Matomo.hooks.php"
+		"MediaWiki\\Extension\\Matomo\\Hooks": "src/Hooks.php"
 	},
 	"manifest_version": 1
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -1,6 +1,8 @@
 <?php
 
-class MatomoHooks {
+namespace MediaWiki\Extension\Matomo;
+
+class Hooks {
 
 	/** @var string|null Searched term in Special:Search. */
 	public static $searchTerm = null;


### PR DESCRIPTION
This removes on phpcs exclusion and uses some more modern MediaWiki
conventions.