### PR TITLE
Prevent doubled output if hook is called repeatedly

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -24,7 +24,10 @@ class Hooks {
 	 * @return bool
 	 */
 	public static function MatomoSetup( $skin, &$text = '' ) {
-		$text .= self::addMatomo( $skin->getTitle() );
+		if (!str_contains($text, 'Matomo')) {
+			$text .= self::addMatomo( $skin->getTitle() );
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
MediaWiki, at least since version 1.39, calls the `SkinAfterBottomScripts` hook twice. This patch prevents the output from being doubled.