### PR TITLE
Update required composer/installers version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         ],
 	"require": {
 		"php": ">=5.3.0",
-		"composer/installers": "1.*,>=1.0.1"
+		"composer/installers": "^1|^2"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Allow `composer/installer` version 2 as well as 1
for easier compatibility with other extensions.